### PR TITLE
Start sampling close to default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ pyvela/examples/*_out/
 pyvela/examples/__chain.h5
 __*.h5
 *_out
+__*.pdf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ## Changed
 - Normalize the prior plot in `pyvela-plot` to improve visibility
 - Default PX prior now uses the diameter of the Galaxy as the maximum distance.
+- Choose the starting samples in `pyvela` script closer to the default values.
 ## Fixed
 - Mark Julia lines wrongly missed in coverage with COV_EXCL_LINE to make the coverage % more accurate
 - Make `SPNTA.full_prior_dict()` work properly when "known" priors defined by Vela are used.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Normalize the prior plot in `pyvela-plot` to improve visibility
 - Default PX prior now uses the diameter of the Galaxy as the maximum distance.
 - Choose the starting samples in `pyvela` script closer to the default values.
+- Updated documentation for `pyvela` script.
 ## Fixed
 - Mark Julia lines wrongly missed in coverage with COV_EXCL_LINE to make the coverage % more accurate
 - Make `SPNTA.full_prior_dict()` work properly when "known" priors defined by Vela are used.

--- a/docs/src/priors.md
+++ b/docs/src/priors.md
@@ -138,7 +138,7 @@ More parameters will be added to this table in the future.
 | SINI          | Orbital sine-inclination                                                    | `P(SINI) = SINI / sqrt(1 - SINI^2)`                             | 0 <= SINI <= 1   |
 | STIGMA        | Orthometric Shapiro delay parameter                                         | `P(STIGMA) = 4 * STIGMA / (1 + STIGMA^2)^2`                     | 0 <= STIGMA <= 1 |
 | TNCHROMAMP    | Chromatic noise log-amplitude                                               | `Uniform[-18, -9]`                                              |                  |
-| TNCHROMGAM    | Chromatic noise log-amplitude                                               | `Uniform[0, 7]`                                                 |                  |
+| TNCHROMGAM    | Chromatic noise spectral index                                              | `Uniform[0, 7]`                                                 |                  |
 | TNDMAMP       | DM noise log-amplitude                                                      | `Uniform[-18, -9]`                                              |                  |
 | TNDMGAM       | DM noise spectral index                                                     | `Uniform[0, 7]`                                                 |                  |
 | TNREDAMP      | Spin noise log-amplitude                                                    | `Uniform[-18, -9]`                                              |                  |

--- a/docs/src/pyvela-cli.md
+++ b/docs/src/pyvela-cli.md
@@ -10,7 +10,7 @@ prior distributions, sampler, etc is not necessary. It has the followingb syntax
 ```
 $ pyvela -h
 
-usage: pyvela [-h] [-J JLSO_FILE] [-P PRIOR_FILE] [-T TRUTH] [-C CHEAT_PRIOR_SCALE] [-o OUTDIR] [-f] [-N NSTEPS] [-b BURNIN] [-t THIN] par_file [tim_file]
+usage: pyvela [-h] [-J JLSO_FILE] [-P PRIOR_FILE] [-T TRUTH] [-C CHEAT_PRIOR_SCALE] [-o OUTDIR] [-f] [-N NSTEPS] [-b BURNIN] [-t THIN] [-s INITIAL_SAMPLE_SPREAD] par_file [tim_file]
 
 A command line interface for the Vela.jl pulsar timing & noise analysis package. Uses emcee for sampling. This may not be appropriate for more complex datasets. Write your own scripts for such cases.
 
@@ -37,6 +37,9 @@ options:
   -b BURNIN, --burnin BURNIN
                         Burn-in length for MCMC chains
   -t THIN, --thin THIN  Thinning factor for MCMC chains
+  -s INITIAL_SAMPLE_SPREAD, --initial_sample_spread INITIAL_SAMPLE_SPREAD
+                        Spread of the starting samples around the default parameter values. Must be > 0 and <= 1. 
+                        0 represents no spread and 1 represents prior draws. (default: 0.3)
 ```
 
 This command created saves the MCMC chain and related metadata into an output directory. This includes the following files. The parameter order in all of these files is the same.
@@ -44,18 +47,22 @@ This command created saves the MCMC chain and related metadata into an output di
   - `summary.json` : A `JSON` file containing information about the inputs and the system environment. Useful for debugging.
   - The input `par` and `tim` files
   - The "truth" `par` file (optional, only relevant for simulations)
+  - The input `JSON` file containing user defined priors.
+  - `prior_info.json`: `JSON` file containing the prior distribution for all parameters, including user-defined, default, and 'cheat' priors.
   - `samples.npy` : The `numpy` format file containing the flattened and burned-in MCMC chain. This can be read using [`numpy.load()`](https://numpy.org/doc/stable/reference/generated/numpy.load.html).
   - `samples_raw.npy` : Same as `samples.npy`, but the quantities here are in `Vela.jl`'s internal units.
   - `param_names.txt` : An ordered list of free model parameter names following the `PINT` conventions.
   - `param_prefixes.txt` : An ordered list of free model parameter prefixes following the `PINT` conventions.
   - `param_scale_factors.txt` : An ordered list of scale factors which convert parameter values from `PINT` units to `Vela.jl`'s internal units. The values in `samples.npy` and `samples_raw.npy` are related by these scale factors.
-  - `params_maxpost.txt` : Maximum-posterior sample found in the MCMC chain (May not be the same as the mode of the posterior distribution)
   - `params_median.txt` : The posterior median sample estimated from the MCMC chain
+  - `params_std.txt` : The parameter standard deviations estimated from the MCMC chain
   - `param_units.txt` : Parameter units represented as `astropy.units`-compatible strings. Empty rows represent dimensionless quantities.
   - `param_default_values.txt` : "Pre-fit" values taken from the input par file.
-  - `<PSR>.maxpost.par` : A "post-fit" `par` file containing the maximum-posterior values taken from the MCMC chain.
+  - `param_autocorr.txt`: MCMC autocorrelation length for each free parameter.
   - `<PSR>.median.par` : A "post-fit" `par` file containing the posterior median values taken from the MCMC chain.
-  - `residuals.txt` : Post-fit residuals computed using the posterior median values
+  - `residuals.txt` : Post-fit residuals computed using the posterior median values.
+  - `prior_evals.npy`: The prior distributions evaluated within the posterior distribution range. Used for plotting.
+  - `chain.h5` : HDF5 file containing all samples.
 
 ## `pyvela-plot` script
 

--- a/pyvela/pyvela/pyvela_script.py
+++ b/pyvela/pyvela/pyvela_script.py
@@ -207,8 +207,13 @@ def main(argv=None):
     )
 
     nwalkers = spnta.ndim * 5
-    p0 = np.array(
+    p0_ = np.array(
         [spnta.prior_transform(cube) for cube in np.random.rand(nwalkers, spnta.ndim)]
+    )
+    p0 = (
+        (5 * spnta.default_params + p0_) / 6
+        if np.isfinite(spnta.lnpost(spnta.default_params))
+        else p0_
     )
 
     sampler = emcee.EnsembleSampler(


### PR DESCRIPTION
Default values usually represent a frequentist fit. They are likely to be close to the mode of the posterior. This will help the chain burn in faster.