### PR TITLE
Summary file now reports start and stop times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Default priors for T0, TASC, JUMP, M2, and H3.
 - Comments about the source of default priors.
 - `SPNTA.marginalized_param_names()` method and `get_marginalized_param_names()` function
+- Summary file has start and stop times
 ## Changed
 - Normalize the prior plot in `pyvela-plot` to improve visibility
 - Default PX prior now uses the diameter of the Galaxy as the maximum distance.

--- a/pyvela/pyvela/spnta.py
+++ b/pyvela/pyvela/spnta.py
@@ -111,6 +111,7 @@ class SPNTA:
         self.timfile = timfile
         self.jlsofile: Optional[str] = None
         self.custom_prior_file: Optional[str] = None
+        self.starttime = datetime.datetime.now().isoformat()
 
         self.cheat_prior_scale: Optional[float] = cheat_prior_scale
 
@@ -584,7 +585,8 @@ class SPNTA:
             },
             "sampler": sampler_info,
             "env": {
-                "launch_time": datetime.datetime.now().isoformat(),
+                "launch_time": self.starttime,
+                "stop_time": datetime.datetime.now().isoformat(),
                 "user": getpass.getuser(),
                 "host": platform.node(),
                 "os": platform.platform(),


### PR DESCRIPTION
What had been `launch_time` in the summary file was in fact when the file was written.  Added new attribute `spnta.starttime`, and that is now included along with `stop_time` in `summary.json`